### PR TITLE
Dynamic input helper and example

### DIFF
--- a/examples/dynamic/index.html
+++ b/examples/dynamic/index.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <div id="app"></div>
+  <script src="./index.tsx"></script>
+</body>
+</html>

--- a/examples/dynamic/index.tsx
+++ b/examples/dynamic/index.tsx
@@ -1,0 +1,116 @@
+import { sequenceS } from 'fp-ts/lib/Apply';
+import * as A from 'fp-ts/lib/Array';
+import * as E from 'fp-ts/lib/Either';
+import { eqNumber } from 'fp-ts/lib/Eq';
+import * as M from 'fp-ts/lib/Map';
+import * as O from 'fp-ts/lib/Option';
+import { ordNumber } from 'fp-ts/lib/Ord';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { Lens } from 'monocle-ts';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as F from '../../src/Form';
+import * as V from '../../src/Validated';
+
+type Team = { teamName: string; players: Map<number, string> };
+type TeamFormData = {
+	teamName: V.Validated<string>;
+	players: PlayersFormData;
+};
+
+type PlayersFormData = Map<number, V.Validated<string>>;
+
+// lenses
+const _teamName = Lens.fromProp<TeamFormData>()('teamName');
+const _players = Lens.fromProp<TeamFormData>()('players');
+
+// general inputs
+const textbox: F.Form<string, string> = (i) => ({
+	ui: (onChange) => <input onChange={(e) => onChange(e.target.value)} />,
+	result: O.some(i)
+});
+
+// validators
+const nonEmpty: V.Validator<string, string> = E.fromPredicate(
+	(str) => str.length > 0,
+	() => 'Required'
+);
+
+const renderErr = (err: string, ui: React.ReactElement) => (
+	<>
+		{ui}
+		<p>{err}</p>
+	</>
+);
+
+const teamNameForm: F.Form<TeamFormData, string> = pipe(
+	textbox,
+	V.validated(nonEmpty, renderErr),
+	F.focus(_teamName),
+	F.mapUI((ui) => <div>{ui}</div>) // maintain focus
+);
+
+const monoidPlayersForm = F.getMonoid<PlayersFormData, Map<number, string>>(
+	M.getMonoid(eqNumber, { concat: (_a, b) => b }) // semigroup which takes the latest
+);
+
+const playersForm_: F.Form<PlayersFormData, Map<number, string>> = (playersFormData) =>
+	pipe(
+		playersFormData,
+		M.toArray(ordNumber),
+		A.map(([id, playerName]) => {
+			const playerForm = pipe(
+				textbox,
+				V.validated(nonEmpty, renderErr),
+				F.mapUI((form) => (
+					<div>
+						<span>Player {id}</span>
+						<div>{form}</div>
+					</div>
+				)),
+				F.map((nextName) => new Map([[id, nextName]])) // return a single entry Map which we'll later combine back into the larger map with semigroup
+			);
+
+			const playerFormResult = playerForm(playerName);
+
+			const indexedForm: F.Form<PlayersFormData, Map<number, string>> = (i2) => ({
+				result: playerFormResult.result,
+				ui: (onchange) =>
+					playerFormResult.ui((nextName) => {
+						const next = M.insertAt(eqNumber)(id, nextName)(i2);
+						onchange(next);
+					})
+			});
+
+			return indexedForm;
+		}),
+		(forms) => forms.reduce(monoidPlayersForm.concat, monoidPlayersForm.empty),
+		(form) => form(playersFormData)
+	);
+
+const teamForm: F.Form<TeamFormData, Team> = sequenceS(F.form)({
+	teamName: teamNameForm,
+	players: pipe(playersForm_, F.focus(_players))
+});
+
+const App = () => {
+	const [formData, setFormData] = React.useState<TeamFormData>({ teamName: V.fresh(''), players: new Map() });
+	const formResult = teamForm(formData);
+
+	const addPlayer = () => {
+		const newPlayerId = playerId++;
+		const addEmptyPlayer = M.insertAt(eqNumber)(newPlayerId, V.fresh(''));
+		setFormData(_players.modify(addEmptyPlayer));
+	};
+
+	return (
+		<div>
+			{formResult.ui(setFormData)}
+			<button onClick={addPlayer}>Add Player</button>
+			<p>{JSON.stringify(formResult.result)}</p>
+		</div>
+	);
+};
+
+ReactDOM.render(<App />, document.querySelector('#app')!);
+let playerId = 1;

--- a/examples/dynamic/index.tsx
+++ b/examples/dynamic/index.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as F from '../../src/Form';
 import * as V from '../../src/Validated';
-import { multiform } from "../../src/dynamic";
+import { multiform } from '../../src/dynamic';
 
 type Team = { teamName: string; players: Map<number, string> };
 type TeamFormData = {
@@ -51,10 +51,6 @@ const teamNameForm: F.Form<TeamFormData, string> = pipe(
 	F.mapUI((ui) => <div>{ui}</div>) // maintain focus
 );
 
-const monoidPlayersForm = F.getMonoid<PlayersFormData, Map<number, string>>(
-	M.getMonoid(eqNumber, { concat: (_a, b) => b }) // semigroup which takes the latest
-);
-
 const playerForm = pipe(
 	textbox,
 	V.validated(nonEmpty, renderErr),
@@ -65,7 +61,12 @@ const playerForm = pipe(
 	))
 );
 
-const playerMapForm: F.Form<PlayersFormData, Map<number, string>> = multiform(ordNumber, { concat: (_a, b) => b }, playerForm);
+const semigroupPlayerMap = { concat: (_a, b) => b };
+const playerMapForm: F.Form<PlayersFormData, Map<number, string>> = multiform(
+	ordNumber,
+	semigroupPlayerMap,
+	playerForm
+);
 
 const teamForm: F.Form<TeamFormData, Team> = sequenceS(F.form)({
 	teamName: teamNameForm,

--- a/examples/dynamic/index.tsx
+++ b/examples/dynamic/index.tsx
@@ -88,6 +88,7 @@ const App = () => {
 			{formResult.ui(setFormData)}
 			<button onClick={addPlayer}>Add Player</button>
 			<p>{JSON.stringify(formResult.result)}</p>
+			<p>Map contents isn't show with stringify</p>
 		</div>
 	);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fp-ts-form",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "sideEffects": false,

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -82,7 +82,7 @@ export function getMonoid<E,A>(monoidA: Monoid<A>): Monoid<Form<E,A>> {
 		result: O.some(monoidA.empty),
 		ui: () => monoidJSX.empty
 	  })
-	}
+	};
   }
 
 const { map, ap, apFirst, apSecond } = pipeable(form);

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -4,6 +4,7 @@ import { Functor2 } from 'fp-ts/lib/Functor';
 import * as O from 'fp-ts/lib/Option';
 import { pipe, pipeable } from 'fp-ts/lib/pipeable';
 import { Semigroup } from 'fp-ts/lib/Semigroup';
+import { Monoid } from 'fp-ts/lib/Monoid';
 import { Lens } from 'monocle-ts';
 import * as React from 'react';
 import { monoidJSX } from './jsx';
@@ -73,6 +74,16 @@ export function getSemigroup<E, A>(semigroupA: Semigroup<A>): Semigroup<Form<E, 
 		}
 	};
 }
+
+export function getMonoid<E,A>(monoidA: Monoid<A>): Monoid<Form<E,A>> {
+	return {
+	  ...getSemigroup(monoidA),
+	  empty: i => ({
+		result: O.some(monoidA.empty),
+		ui: () => monoidJSX.empty
+	  })
+	}
+  }
 
 const { map, ap, apFirst, apSecond } = pipeable(form);
 export { map, ap, apFirst, apSecond };

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -11,29 +11,29 @@ export const multiform = <K, A, B>(
 	semigroupB: Semigroup<B>,
 	abForm: F.Form<A, B>
 ): F.Form<Map<K, A>, Map<K, B>> => {
-	const monoidKBMap = M.getMonoid(ordK, semigroupB);
-	const monoidABMapForm = F.getMonoid<Map<K, A>, Map<K, B>>(monoidKBMap);
+	const monoidMapB = M.getMonoid(ordK, semigroupB);
+	const monoidABMapForm = F.getMonoid<Map<K, A>, Map<K, B>>(monoidMapB);
 
-	return (kaMap) => {
-		const aMapBMapForm = pipe(
-			kaMap,
+	return (ma) => {
+		const ma_mb_form = pipe(
+			ma,
 			M.toArray(ordK),
 			A.map(([key, aValue]) => {
 				// Run the abForm with A to obtain B
 				// Create a new Form which takes Map<K,A>
 				// and has a prebuilt response of Map<K,B>
 
-				const abFormResult = abForm(aValue);
+				const ab_form_result = abForm(aValue);
 
-				const ma_mb_form: F.Form<Map<K, A>, Map<K, B>> = (kaMap_) => ({
+				const ma_mb_form: F.Form<Map<K, A>, Map<K, B>> = (ma_next) => ({
 					result: pipe(
-						abFormResult.result,
+						ab_form_result.result,
                         O.map((b) => new Map([[key, b]])),
                         O.alt(() => O.some(new Map()))
 					),
 					ui: (onchange) =>
-						abFormResult.ui((nextAValue) => {
-                            const next = M.insertAt(ordK)(key, nextAValue)(kaMap_);
+						ab_form_result.ui((nextAValue) => {
+                            const next = M.insertAt(ordK)(key, nextAValue)(ma_next);
 							onchange(next);
 						})
 				});
@@ -43,6 +43,6 @@ export const multiform = <K, A, B>(
 			(forms) => forms.reduce(monoidABMapForm.concat, monoidABMapForm.empty)
 		);
 
-		return aMapBMapForm(kaMap);
+		return ma_mb_form(ma);
 	};
 };

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -1,0 +1,44 @@
+import * as A from 'fp-ts/lib/Array';
+import * as M from 'fp-ts/lib/Map';
+import { Ord } from 'fp-ts/lib/Ord';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { Semigroup } from 'fp-ts/lib/Semigroup';
+import * as F from './Form';
+
+export const multiform = <K, A, B>(
+	ordK: Ord<K>,
+	semigroupB: Semigroup<B>,
+	abForm: F.Form<A, B>
+): F.Form<Map<K, A>, Map<K, B>> => {
+	const monoidKBMap = M.getMonoid(ordK, semigroupB);
+    const monoidABMapForm = F.getMonoid<Map<K, A>, Map<K, B>>(monoidKBMap);
+
+	return (kaMap) => {
+		const aMapBMapForm = pipe(
+			kaMap,
+			M.toArray(ordK),
+			A.map(([key, aValue]) => {
+				const abMapForm = pipe(
+					abForm,
+					F.map((bValue) => new Map([[key, bValue]]))
+				);
+
+				const formResult = abMapForm(aValue);
+
+				const indexedForm: F.Form<Map<K, A>, Map<K, B>> = (i2) => ({
+					result: formResult.result,
+					ui: (onchange) =>
+						formResult.ui((nextBValue) => {
+							const next = M.insertAt(ordK)(key, nextBValue)(i2);
+							onchange(next);
+						})
+				});
+
+				return indexedForm;
+			}),
+			(forms) => forms.reduce(monoidABMapForm.concat, monoidABMapForm.empty)
+		);
+
+		return aMapBMapForm(kaMap);
+	};
+};

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -28,11 +28,12 @@ export const multiform = <K, A, B>(
 				const ma_mb_form: F.Form<Map<K, A>, Map<K, B>> = (kaMap_) => ({
 					result: pipe(
 						abFormResult.result,
-						O.map((b) => new Map([[key, b]]))
+                        O.map((b) => new Map([[key, b]])),
+                        O.alt(() => O.some(new Map()))
 					),
 					ui: (onchange) =>
 						abFormResult.ui((nextAValue) => {
-							const next = M.insertAt(ordK)(key, nextAValue)(kaMap_);
+                            const next = M.insertAt(ordK)(key, nextAValue)(kaMap_);
 							onchange(next);
 						})
 				});


### PR DESCRIPTION
Add `multiform` function which lifts `Form<A,B>` to `Form<Map<K,A>, Map<K,B>>` for some supplied key `K`. An example has been added to the examples dir.